### PR TITLE
Run as non-privileged user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM python:3.7-slim
 
 RUN pip install snmpsim
 
-RUN adduser --system snmpsim
+RUN adduser --system --uid 1000 snmpsim
 
 ADD data /usr/local/snmpsim/data
 
 EXPOSE 161/udp
 
-CMD snmpsimd.py --agent-udpv4-endpoint=0.0.0.0:161 --process-user=snmpsim --process-group=nogroup $EXTRA_FLAGS
+USER snmpsim
+
+CMD snmpsimd.py --agent-udpv4-endpoint=0.0.0.0:161 $EXTRA_FLAGS


### PR DESCRIPTION
This PR lower the privileges with which the containerized process will run.
The process will run as the created non-privileged _snmpsim_ user with ID 1000.

This setup fixes also [this issue](https://github.com/etingof/snmpsim/issues/84) of which [this fix](https://github.com/etingof/snmpsim/pull/92) has never been released.